### PR TITLE
build scripts: resolve ESP-IDF, Python env, and repo root from enviro…

### DIFF
--- a/ESP32_P4_PAPP_Template/build_template.ps1
+++ b/ESP32_P4_PAPP_Template/build_template.ps1
@@ -17,8 +17,8 @@ $SRC = Join-Path (Join-Path $ROOT "ESP32_P4_PAPP_Template") "main.c"
 
 # Source ESP-IDF if not already done
 if (-not (Get-Command "riscv32-esp-elf-gcc" -ErrorAction SilentlyContinue)) {
-    $env:IDF_PYTHON_ENV_PATH = "C:\Users\97254\.espressif\python_env\idf5.5_py3.12_env"
-    & "C:\Users\97254\esp\v5.5.2\esp-idf\export.ps1" 2>$null
+    . (Join-Path $ROOT 'tools\Resolve-IdfEnv.ps1')
+    Initialize-IdfEnv
 }
 
 New-Item -ItemType Directory -Force -Path $BUILD | Out-Null

--- a/build_all.ps1
+++ b/build_all.ps1
@@ -1,17 +1,14 @@
 # build_all.ps1 — Build the launcher and all emulator apps
 # Usage: .\build_all.ps1
-# Requires ESP-IDF environment to be active
+# Uses $env:IDF_PATH and $env:IDF_PYTHON_ENV_PATH if set; auto-detects otherwise.
 
 $ErrorActionPreference = "Stop"
 
-# Ensure ESP-IDF environment is loaded
-$env:IDF_PYTHON_ENV_PATH = "C:\Users\97254\.espressif\python_env\idf5.5_py3.12_env"
-$ErrorActionPreference = "Continue"
-& "C:\Users\97254\esp\v5.5.2\esp-idf\export.ps1" 2>$null
-$ErrorActionPreference = "Stop"
+$ROOT = $PSScriptRoot
+. (Join-Path $ROOT 'tools\Resolve-IdfEnv.ps1')
+Initialize-IdfEnv
 
-$ROOT = "C:\ESPIDFprojects\RetroESP32_P4"
-$BINS = "$ROOT\firmware"
+$BINS = Join-Path $ROOT 'firmware'
 New-Item -ItemType Directory -Path $BINS -Force | Out-Null
 
 # ── Build Launcher ──────────────────────────────────────────────

--- a/build_all_hdmi.bat
+++ b/build_all_hdmi.bat
@@ -6,15 +6,18 @@ echo ============================================
 echo  RetroESP32-P4 Full HDMI Build
 echo ============================================
 
-REM Activate ESP-IDF environment
-call "C:\Users\97254\esp\v5.5.2\esp-idf\export.bat"
+REM Resolve $ROOT from this script's location.
+set "ROOT=%~dp0"
+if "%ROOT:~-1%"=="\" set "ROOT=%ROOT:~0,-1%"
+
+REM Activate ESP-IDF environment (honors IDF_PATH / IDF_PYTHON_ENV_PATH, else auto-detects).
+call "%ROOT%\tools\resolve_idf_env.bat"
 if errorlevel 1 (
     echo ERROR: Failed to activate ESP-IDF environment
     pause
     exit /b 1
 )
 
-set ROOT=C:\ESPIDFprojects\RetroESP32_P4
 set BINS=%ROOT%\firmware_hdmi
 set HDMI_DEFAULTS=%ROOT%\launcher\sdkconfig.hdmi.defaults
 if not exist "%BINS%" mkdir "%BINS%"

--- a/build_all_lcd.bat
+++ b/build_all_lcd.bat
@@ -6,15 +6,18 @@ echo ============================================
 echo  RetroESP32-P4 Full LCD Build
 echo ============================================
 
-REM Activate ESP-IDF environment
-call "C:\Users\97254\esp\v5.5.2\esp-idf\export.bat"
+REM Resolve $ROOT from this script's location.
+set "ROOT=%~dp0"
+if "%ROOT:~-1%"=="\" set "ROOT=%ROOT:~0,-1%"
+
+REM Activate ESP-IDF environment (honors IDF_PATH / IDF_PYTHON_ENV_PATH, else auto-detects).
+call "%ROOT%\tools\resolve_idf_env.bat"
 if errorlevel 1 (
     echo ERROR: Failed to activate ESP-IDF environment
     pause
     exit /b 1
 )
 
-set ROOT=C:\ESPIDFprojects\RetroESP32_P4
 set BINS=%ROOT%\firmware
 if not exist "%BINS%" mkdir "%BINS%"
 

--- a/build_hdmi.ps1
+++ b/build_hdmi.ps1
@@ -1,17 +1,14 @@
 # build_hdmi.ps1 — Build the launcher and all emulator apps for HDMI output
 # Usage: .\build_hdmi.ps1
-# Requires ESP-IDF environment to be active
+# Uses $env:IDF_PATH and $env:IDF_PYTHON_ENV_PATH if set; auto-detects otherwise.
 
 $ErrorActionPreference = "Stop"
 
-# Ensure ESP-IDF environment is loaded
-$env:IDF_PYTHON_ENV_PATH = "C:\Users\97254\.espressif\python_env\idf5.5_py3.12_env"
-$ErrorActionPreference = "Continue"
-& "C:\Users\97254\esp\v5.5.2\esp-idf\export.ps1" 2>$null
-$ErrorActionPreference = "Stop"
+$ROOT = $PSScriptRoot
+. (Join-Path $ROOT 'tools\Resolve-IdfEnv.ps1')
+Initialize-IdfEnv
 
-$ROOT = "C:\ESPIDFprojects\RetroESP32_P4"
-$BINS = "$ROOT\firmware_hdmi"
+$BINS = Join-Path $ROOT 'firmware_hdmi'
 New-Item -ItemType Directory -Path $BINS -Force | Out-Null
 
 # HDMI sdkconfig overlay — merged with per-app sdkconfig.defaults

--- a/flash_all.ps1
+++ b/flash_all.ps1
@@ -1,16 +1,16 @@
-# flash_all.ps1 -- Flash all binaries to ESP32-P4 via COM30
+# flash_all.ps1 -- Flash all binaries to ESP32-P4
 # Usage: .\flash_all.ps1
-# Requires ESP-IDF environment to be active
+# Uses $env:IDF_PATH and $env:IDF_PYTHON_ENV_PATH if set; auto-detects otherwise.
+# Port defaults to COM30; override with $env:ESP_PORT.
 
 $ErrorActionPreference = "Continue"
 
-# Ensure ESP-IDF environment is loaded
-$env:IDF_PYTHON_ENV_PATH = "C:\Users\97254\.espressif\python_env\idf5.5_py3.12_env"
-& "C:\Users\97254\esp\v5.5.2\esp-idf\export.ps1" 2>$null
+$ROOT = $PSScriptRoot
+. (Join-Path $ROOT 'tools\Resolve-IdfEnv.ps1')
+Initialize-IdfEnv
 
-$ROOT = "C:\ESPIDFprojects\RetroESP32_P4"
-$BINS = "$ROOT\firmware"
-$PORT = "COM30"
+$BINS = Join-Path $ROOT 'firmware'
+$PORT = if ($env:ESP_PORT) { $env:ESP_PORT } else { "COM30" }
 
 # Kill any python processes holding the port
 Stop-Process -Name python -Force -ErrorAction SilentlyContinue

--- a/generate_merged_bin.ps1
+++ b/generate_merged_bin.ps1
@@ -13,9 +13,12 @@
 
 $ErrorActionPreference = "Stop"
 
-$ROOT = "C:\ESPIDFprojects\RetroESP32_P4"
-$BINS = "$ROOT\firmware"
-$OUT  = "$ROOT\RetroESP32_P4_v1.bin"
+$ROOT = $PSScriptRoot
+. (Join-Path $ROOT 'tools\Resolve-IdfEnv.ps1')
+Initialize-IdfEnv
+
+$BINS = Join-Path $ROOT 'firmware'
+$OUT  = Join-Path $ROOT 'RetroESP32_P4_v1.bin'
 
 # Flash map (must match partitions_ota.csv)
 # Format: offset, filename, description

--- a/generate_merged_bin_hdmi.ps1
+++ b/generate_merged_bin_hdmi.ps1
@@ -10,9 +10,12 @@
 
 $ErrorActionPreference = "Stop"
 
-$ROOT = "C:\ESPIDFprojects\RetroESP32_P4"
-$BINS = "$ROOT\firmware_hdmi"
-$OUT  = "$ROOT\RetroESP32_P4_HDMI_v1.bin"
+$ROOT = $PSScriptRoot
+. (Join-Path $ROOT 'tools\Resolve-IdfEnv.ps1')
+Initialize-IdfEnv
+
+$BINS = Join-Path $ROOT 'firmware_hdmi'
+$OUT  = Join-Path $ROOT 'RetroESP32_P4_HDMI_v1.bin'
 
 # Flash map (must match partitions_ota.csv)
 $offsets = @("0x2000","0x8000","0xD000","0x10000","0x0D0000","0x160000","0x200000","0x350000","0x410000","0x550000","0x5F0000","0x690000","0x740000","0x8C0000","0x9B0000","0xB00000")

--- a/tools/Resolve-IdfEnv.ps1
+++ b/tools/Resolve-IdfEnv.ps1
@@ -1,0 +1,44 @@
+# Resolve ESP-IDF + Python env paths from env vars, with auto-detection fallback.
+# Dot-source this file, then call: Initialize-IdfEnv
+
+function Find-NewestPath {
+    param([string[]]$Patterns)
+    foreach ($p in $Patterns) {
+        $hit = Get-ChildItem -Path $p -Directory -ErrorAction SilentlyContinue |
+               Sort-Object LastWriteTime -Descending | Select-Object -First 1
+        if ($hit) { return $hit.FullName }
+    }
+    return $null
+}
+
+function Initialize-IdfEnv {
+    if (-not $env:IDF_PATH -or -not (Test-Path $env:IDF_PATH)) {
+        $env:IDF_PATH = Find-NewestPath @(
+            (Join-Path $env:USERPROFILE 'esp\*\esp-idf'),
+            'C:\esp\*\esp-idf'
+        )
+    }
+    if (-not $env:IDF_PATH) {
+        throw "ESP-IDF not found. Set `$env:IDF_PATH or install under %USERPROFILE%\esp\<ver>\esp-idf."
+    }
+
+    if (-not $env:IDF_PYTHON_ENV_PATH -or -not (Test-Path $env:IDF_PYTHON_ENV_PATH)) {
+        $env:IDF_PYTHON_ENV_PATH = Find-NewestPath @(
+            (Join-Path $env:USERPROFILE '.espressif\python_env\idf*_env')
+        )
+    }
+    if (-not $env:IDF_PYTHON_ENV_PATH) {
+        throw "IDF Python env not found. Set `$env:IDF_PYTHON_ENV_PATH or run the IDF installer."
+    }
+
+    Write-Host "IDF_PATH            = $env:IDF_PATH"
+    Write-Host "IDF_PYTHON_ENV_PATH = $env:IDF_PYTHON_ENV_PATH"
+
+    $export = Join-Path $env:IDF_PATH 'export.ps1'
+    if (-not (Test-Path $export)) { throw "export.ps1 missing at $export" }
+
+    $prev = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    & $export 2>$null
+    $ErrorActionPreference = $prev
+}

--- a/tools/build_doom_papp.ps1
+++ b/tools/build_doom_papp.ps1
@@ -12,7 +12,9 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
-$ROOT = "C:\ESPIDFprojects\RetroESP32_P4"
+$ROOT = Split-Path -Parent $PSScriptRoot
+. (Join-Path $PSScriptRoot 'Resolve-IdfEnv.ps1')
+Initialize-IdfEnv
 $BUILD = "$ROOT\build_papp\doom"
 $OUT   = "$ROOT\firmware\doom.papp"
 

--- a/tools/build_duke3d_papp.ps1
+++ b/tools/build_duke3d_papp.ps1
@@ -12,7 +12,9 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
-$ROOT  = "C:\ESPIDFprojects\RetroESP32_P4"
+$ROOT  = Split-Path -Parent $PSScriptRoot
+. (Join-Path $PSScriptRoot 'Resolve-IdfEnv.ps1')
+Initialize-IdfEnv
 $BUILD = "$ROOT\build_papp\duke3d"
 $OUT   = "$ROOT\firmware\duke3d.papp"
 

--- a/tools/build_lvgl_papp.ps1
+++ b/tools/build_lvgl_papp.ps1
@@ -31,6 +31,8 @@ $ErrorActionPreference = "Continue"
 
 $ROOT      = Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)
 $TOOLS_DIR = Join-Path $ROOT "tools"
+. (Join-Path $TOOLS_DIR 'Resolve-IdfEnv.ps1')
+Initialize-IdfEnv
 $APP_DIR   = Join-Path (Join-Path $ROOT "apps") $AppName
 $LVGL_DIR  = Join-Path (Join-Path $ROOT "third_party") "lvgl"
 $BUILD_DIR = Join-Path (Join-Path $ROOT "build_papp") $AppName

--- a/tools/build_opentyrian_papp.ps1
+++ b/tools/build_opentyrian_papp.ps1
@@ -12,7 +12,9 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
-$ROOT = "C:\ESPIDFprojects\RetroESP32_P4"
+$ROOT = Split-Path -Parent $PSScriptRoot
+. (Join-Path $PSScriptRoot 'Resolve-IdfEnv.ps1')
+Initialize-IdfEnv
 $BUILD = "$ROOT\build_papp\opentyrian"
 $OUT   = "$ROOT\firmware\opentyrian.papp"
 

--- a/tools/build_psram_app.ps1
+++ b/tools/build_psram_app.ps1
@@ -28,6 +28,8 @@ $ErrorActionPreference = "Stop"
 
 $ROOT      = Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)
 $TOOLS_DIR = Join-Path $ROOT "tools"
+. (Join-Path $TOOLS_DIR 'Resolve-IdfEnv.ps1')
+Initialize-IdfEnv
 $BUILD_DIR = Join-Path (Join-Path $ROOT "build_papp") $AppName
 $FW_DIR    = Join-Path $ROOT "firmware"
 $LD_SCRIPT = Join-Path $TOOLS_DIR "psram_app.ld"

--- a/tools/build_quake_papp.ps1
+++ b/tools/build_quake_papp.ps1
@@ -12,7 +12,9 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
-$ROOT = "C:\ESPIDFprojects\RetroESP32_P4"
+$ROOT = Split-Path -Parent $PSScriptRoot
+. (Join-Path $PSScriptRoot 'Resolve-IdfEnv.ps1')
+Initialize-IdfEnv
 $BUILD = "$ROOT\build_papp\quake"
 $OUT   = "$ROOT\firmware\quake.papp"
 

--- a/tools/resolve_idf_env.bat
+++ b/tools/resolve_idf_env.bat
@@ -1,0 +1,51 @@
+@echo off
+REM resolve_idf_env.bat -- Resolve ESP-IDF + Python env paths and source export.bat.
+REM Honors IDF_PATH and IDF_PYTHON_ENV_PATH if set; otherwise picks the newest
+REM matching install under %USERPROFILE%\esp\* and %USERPROFILE%\.espressif\python_env\*.
+REM
+REM Usage:  call "<path>\tools\resolve_idf_env.bat"  || exit /b 1
+
+REM --- ESP-IDF -----------------------------------------------------------
+if defined IDF_PATH if exist "%IDF_PATH%\export.bat" goto :idf_ok
+
+set "IDF_PATH="
+for /f "delims=" %%D in ('dir /b /ad /o-d "%USERPROFILE%\esp\*" 2^>nul') do (
+    if not defined IDF_PATH if exist "%USERPROFILE%\esp\%%D\esp-idf\export.bat" (
+        set "IDF_PATH=%USERPROFILE%\esp\%%D\esp-idf"
+    )
+)
+if not defined IDF_PATH (
+    for /f "delims=" %%D in ('dir /b /ad /o-d "C:\esp\*" 2^>nul') do (
+        if not defined IDF_PATH if exist "C:\esp\%%D\esp-idf\export.bat" (
+            set "IDF_PATH=C:\esp\%%D\esp-idf"
+        )
+    )
+)
+if not defined IDF_PATH (
+    echo ERROR: ESP-IDF not found. Set IDF_PATH or install under %%USERPROFILE%%\esp\^<ver^>\esp-idf.
+    exit /b 1
+)
+
+:idf_ok
+
+REM --- Python env (must be set BEFORE export.bat runs) --------------------
+if defined IDF_PYTHON_ENV_PATH if exist "%IDF_PYTHON_ENV_PATH%" goto :py_ok
+
+set "IDF_PYTHON_ENV_PATH="
+for /f "delims=" %%D in ('dir /b /ad /o-d "%USERPROFILE%\.espressif\python_env\idf*_env" 2^>nul') do (
+    if not defined IDF_PYTHON_ENV_PATH (
+        set "IDF_PYTHON_ENV_PATH=%USERPROFILE%\.espressif\python_env\%%D"
+    )
+)
+if not defined IDF_PYTHON_ENV_PATH (
+    echo ERROR: IDF Python env not found. Set IDF_PYTHON_ENV_PATH or run the IDF installer.
+    exit /b 1
+)
+
+:py_ok
+
+echo IDF_PATH            = %IDF_PATH%
+echo IDF_PYTHON_ENV_PATH = %IDF_PYTHON_ENV_PATH%
+
+call "%IDF_PATH%\export.bat"
+exit /b %ERRORLEVEL%


### PR DESCRIPTION
Auto resolve ESP-IDF, Python env and repo root

Every .ps1 and .bat build/flash script hardcoded C:\Users\97254\... for the IDF and Python-env install and C:\ESPIDFprojects\RetroESP32_P4 for the repo, which only worked on the original author's machine.

Now:
- $ROOT / %ROOT% derives from the script's own location ($PSScriptRoot / %~dp0).
- ESP-IDF is picked from $env:IDF_PATH if set, else the newest match under %USERPROFILE%\esp\<ver>\esp-idf (fallback: C:\esp\<ver>\esp-idf).
- Python env is picked from $env:IDF_PYTHON_ENV_PATH if set, else the newest %USERPROFILE%\.espressif\python_env\idf*_env.
- flash_all.ps1 port now honors $env:ESP_PORT (default: COM30).
- Missing IDF / Python env fails fast with a clear message.

Shared resolvers live in tools\Resolve-IdfEnv.ps1 (PowerShell) and tools\resolve_idf_env.bat (cmd.exe); every other script sources one of them.