### PR TITLE
Defined GT911 INT & RST pins; don't use polling

### DIFF
--- a/main/pins_config.h
+++ b/main/pins_config.h
@@ -13,8 +13,8 @@
 /* Touch I2C Pins */
 #define TP_I2C_SDA  7
 #define TP_I2C_SCL  8
-#define TP_RST      -1
-#define TP_INT      -1
+#define TP_RST      22
+#define TP_INT      21
 
 /* I2S / ES8311 Audio Codec Pins */
 #define I2S_MCLK_IO   13


### PR DESCRIPTION
Defined as per [this](https://reddit.com/r/esp32/comments/1nml6fm/comment/ng8r63s) schematic. Enables to use interrupts instead of polling the touch panel, hopefully reducing input lag.

Note: untested in this project — just ported from my own code.